### PR TITLE
Corrected mismatching paths to DH parameters file

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -83,9 +83,9 @@
 
 - name: Generate Diffie-Hellman parameters
   become: yes
-  shell: "openssl dhparam -out {{ easy_rsa_key_dir }}/dh{{ easy_rsa_key_size }}.pem {{ easy_rsa_key_size }}"
+  shell: "openssl dhparam -out dh{{ easy_rsa_key_size }}.pem {{ easy_rsa_key_size }}"
   args:
-    chdir: "{{ easy_rsa_ca_dir }}"
+    chdir: "{{ easy_rsa_key_dir }}"
     creates: "{{ easy_rsa_key_dir }}/dh{{ easy_rsa_key_size }}.pem"
   tags:
     - easy_rsa

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -83,7 +83,7 @@
 
 - name: Generate Diffie-Hellman parameters
   become: yes
-  shell: "openssl dhparam -out dh{{ easy_rsa_key_size }}.pem {{ easy_rsa_key_size }}"
+  shell: "openssl dhparam -out {{ easy_rsa_key_dir }}/dh{{ easy_rsa_key_size }}.pem {{ easy_rsa_key_size }}"
   args:
     chdir: "{{ easy_rsa_ca_dir }}"
     creates: "{{ easy_rsa_key_dir }}/dh{{ easy_rsa_key_size }}.pem"


### PR DESCRIPTION
In the Diffie-Hellman task, the `openssl` command creates the parameters file in `{{ easy_rsa_ca_dir }}` (as dictated by the `chdir` argument), but the `creates` argument incorrectly says it's in `{{ easy_rsa_key_dir }}`. This means that every time the playbook runs, it looks in the wrong place for the file, doesn't find it, and thus unnecessarily re-runs the command.

This PR adjusts the `creates` argument to look for the parameters file in the location that it actually is, thus preventing unnecessary re-runs of the task.